### PR TITLE
chore: upgrade Comark to v0.6.0

### DIFF
--- a/modules/content.ts
+++ b/modules/content.ts
@@ -6,7 +6,7 @@ import {
   createResolver,
   defineNuxtModule,
 } from "@nuxt/kit";
-import { parse } from "comark";
+import { parseMarkdown } from "comark";
 import highlight from "comark/plugins/highlight";
 import matter from "gray-matter";
 import { z } from "zod";
@@ -51,7 +51,7 @@ async function parseArticle(
   const slug = slugFromFilePath(filePath);
   const { data, content } = matter(rawMarkdown);
   const frontmatter = frontmatterSchema.parse(data);
-  const tree = await parse(content.trim(), {
+  const document = await parseMarkdown(content.trim(), {
     plugins: [highlight()],
   });
 
@@ -60,7 +60,7 @@ async function parseArticle(
     _id: `content:blog:${slug}`,
     slug,
     path: `/blog/${slug}`,
-    tree,
+    document,
     excerpt: excerptFromBody(content),
     date: frontmatter.date.toISOString(),
   };
@@ -96,7 +96,7 @@ export default defineNuxtModule({
 
         return `const articles = ${JSON.stringify(articles, null, 2)}
 
-const articleSummaries = articles.map(({ tree, ...article }) => article)
+const articleSummaries = articles.map(({ document, ...article }) => article)
 
 export function getAllBlogArticles(options = {}) {
   if (options.includeDrafts) {

--- a/modules/content/runtime/types/blog-article.ts
+++ b/modules/content/runtime/types/blog-article.ts
@@ -2,7 +2,7 @@ export type BlogArticle = {
   _id: string;
   slug: string;
   path: string;
-  tree: unknown;
+  document: unknown;
   excerpt: string;
   title?: string;
   description?: string;
@@ -17,4 +17,4 @@ export type BlogArticle = {
   draft?: boolean;
 };
 
-export type BlogArticleSummary = Omit<BlogArticle, "tree">;
+export type BlogArticleSummary = Omit<BlogArticle, "document">;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --parser vue components/ pages/ layouts/ --write"
   },
   "devDependencies": {
-    "@comark/nuxt": "^0.5.1",
+    "@comark/nuxt": "^0.6.0",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@tailwindcss/typography": "^0.5.16",
     "feed": "^4.2.2",

--- a/pages/blog/[...slug].vue
+++ b/pages/blog/[...slug].vue
@@ -190,7 +190,7 @@ function externalSite(p: any) {
     <article
       class="prose max-w-[1024px] text-gray-300 prose-headings:text-white prose-h2:mt-8 prose-h2:border-b prose-h2:border-white/10 prose-h2:pb-2 prose-h3:text-orange-100 prose-a:font-bold prose-a:text-orange-400 prose-a:no-underline hover:prose-a:text-orange-200 prose-blockquote:text-gray-400 prose-strong:text-gray-100 prose-code:text-white prose-pre:bg-black/70 prose-li:my-0"
     >
-      <ComarkRenderer v-if="page?.tree" :tree="page.tree" />
+      <MarkdownDocument v-if="page?.document" :value="page.document" />
     </article>
   </div>
 </template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         version: 3.4.17
     devDependencies:
       '@comark/nuxt':
-        specifier: ^0.5.1
-        version: 0.5.1(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@netlify/blobs@9.1.2)(@oxc-project/types@0.142.0)(@types/node@22.15.24)(@vue/compiler-sfc@3.5.40)(better-sqlite3@12.4.1)(db0@0.3.4(better-sqlite3@12.4.1))(esbuild@0.28.1)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.1)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.0)(typescript@5.9.3)(vite@8.2.0(@types/node@22.15.24)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.99.9(esbuild@0.28.1))(yaml@2.9.0))(oxc-parser@0.140.0)(rolldown@1.2.1)(shiki@4.4.1)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.2.0(@types/node@22.15.24)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.99.9(esbuild@0.28.1)))(vue@3.5.40(typescript@5.9.3))
+        specifier: ^0.6.0
+        version: 0.6.0(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@netlify/blobs@9.1.2)(@oxc-project/types@0.142.0)(@types/node@22.15.24)(@vue/compiler-sfc@3.5.40)(better-sqlite3@12.4.1)(db0@0.3.4(better-sqlite3@12.4.1))(esbuild@0.28.1)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.1)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.0)(typescript@5.9.3)(vite@8.2.0(@types/node@22.15.24)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.99.9(esbuild@0.28.1))(yaml@2.9.0))(oxc-parser@0.140.0)(rolldown@1.2.1)(shiki@4.4.1)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.2.0(@types/node@22.15.24)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.99.9(esbuild@0.28.1)))(vue@3.5.40(typescript@5.9.3))
       '@nuxtjs/tailwindcss':
         specifier: ^6.14.0
         version: 6.14.0(magicast@0.5.4)
@@ -229,13 +229,13 @@ packages:
   '@colordx/core@5.5.0':
     resolution: {integrity: sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==}
 
-  '@comark/nuxt@0.5.1':
-    resolution: {integrity: sha512-BvXUbzasGRqQ6bWGuRMO0E6KhWXXpv8FpursPHTixTwJxYVa7BFHUVqvq4cfjj5/6VgbXwofvHiawVQV2k33og==}
+  '@comark/nuxt@0.6.0':
+    resolution: {integrity: sha512-oyNlqqOSsvxYW1ObZvloXUfADupjYfbxhhqc/I9MWweboC+/HsEXDB341TKXyTkwUISIOvpTcChP8tWjfrB/ww==}
     peerDependencies:
       nuxt: ^4.0.0
 
-  '@comark/vue@0.5.1':
-    resolution: {integrity: sha512-uz5Oirzg7ruuJJItceWRswAftuMoY17Omge9bsUampmAL/XdI77YrBOozA5DlId+OCX0VXnt1tCCe4c1IrcJ7w==}
+  '@comark/vue@0.6.0':
+    resolution: {integrity: sha512-c7BxpneMTWcA34OabdMetm1+Q2ANTbPdSpqNESaFB2cVB7i5IufmA5jjEyQkXWw24/ChfBbvT6BQkib2BxHqSQ==}
     peerDependencies:
       beautiful-mermaid: ^1.1.3
       katex: ^0.17.0
@@ -1727,8 +1727,8 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  comark@0.5.1:
-    resolution: {integrity: sha512-RRRmUaEc6tokYJhgIGHrl8+pUt3kY1BxMnbRrxMxkCk2RcPcrilq9OmmPWIO7zuUIF7qLLRCCQz+wPuMg7Vz9w==}
+  comark@0.6.0:
+    resolution: {integrity: sha512-+0TRU6agbL0qadduzT9FnTSkvukHA3+B2p4rbu/xlfwRLL1LrJVtUS/NVF5OYetrCpRhOL9/Zgu/7fuqIqXyZg==}
     peerDependencies:
       beautiful-mermaid: ^1.1.3
       katex: ^0.17.0
@@ -4871,11 +4871,11 @@ snapshots:
 
   '@colordx/core@5.5.0': {}
 
-  '@comark/nuxt@0.5.1(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@netlify/blobs@9.1.2)(@oxc-project/types@0.142.0)(@types/node@22.15.24)(@vue/compiler-sfc@3.5.40)(better-sqlite3@12.4.1)(db0@0.3.4(better-sqlite3@12.4.1))(esbuild@0.28.1)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.1)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.0)(typescript@5.9.3)(vite@8.2.0(@types/node@22.15.24)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.99.9(esbuild@0.28.1))(yaml@2.9.0))(oxc-parser@0.140.0)(rolldown@1.2.1)(shiki@4.4.1)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.2.0(@types/node@22.15.24)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.99.9(esbuild@0.28.1)))(vue@3.5.40(typescript@5.9.3))':
+  '@comark/nuxt@0.6.0(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@netlify/blobs@9.1.2)(@oxc-project/types@0.142.0)(@types/node@22.15.24)(@vue/compiler-sfc@3.5.40)(better-sqlite3@12.4.1)(db0@0.3.4(better-sqlite3@12.4.1))(esbuild@0.28.1)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.1)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.0)(typescript@5.9.3)(vite@8.2.0(@types/node@22.15.24)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.99.9(esbuild@0.28.1))(yaml@2.9.0))(oxc-parser@0.140.0)(rolldown@1.2.1)(shiki@4.4.1)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.2.0(@types/node@22.15.24)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.99.9(esbuild@0.28.1)))(vue@3.5.40(typescript@5.9.3))':
     dependencies:
-      '@comark/vue': 0.5.1(shiki@4.4.1)(vue@3.5.40(typescript@5.9.3))
+      '@comark/vue': 0.6.0(shiki@4.4.1)(vue@3.5.40(typescript@5.9.3))
       '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.2.0(@types/node@22.15.24)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.99.9(esbuild@0.28.1)))
-      comark: 0.5.1(shiki@4.4.1)
+      comark: 0.6.0(shiki@4.4.1)
       nuxt: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@netlify/blobs@9.1.2)(@oxc-project/types@0.142.0)(@types/node@22.15.24)(@vue/compiler-sfc@3.5.40)(better-sqlite3@12.4.1)(db0@0.3.4(better-sqlite3@12.4.1))(esbuild@0.28.1)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.1)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.0)(typescript@5.9.3)(vite@8.2.0(@types/node@22.15.24)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.99.9(esbuild@0.28.1))(yaml@2.9.0)
     transitivePeerDependencies:
       - beautiful-mermaid
@@ -4888,9 +4888,9 @@ snapshots:
       - unplugin
       - vue
 
-  '@comark/vue@0.5.1(shiki@4.4.1)(vue@3.5.40(typescript@5.9.3))':
+  '@comark/vue@0.6.0(shiki@4.4.1)(vue@3.5.40(typescript@5.9.3))':
     dependencies:
-      comark: 0.5.1(shiki@4.4.1)
+      comark: 0.6.0(shiki@4.4.1)
       vue: 3.5.40(typescript@5.9.3)
     optionalDependencies:
       shiki: 4.4.1
@@ -6638,7 +6638,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  comark@0.5.1(shiki@4.4.1):
+  comark@0.6.0(shiki@4.4.1):
     dependencies:
       entities: 8.0.0
       htmlparser2: 12.0.0


### PR DESCRIPTION
This PR upgrades Comark to the latest release.

The changes were applied by AI agents using the migration prompt provided in the release notes:
https://github.com/comarkdown/comark/releases/tag/comark%400.6.0
